### PR TITLE
Revert back to django-environ

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,11 +8,11 @@ asgiref==3.4.1
     # via django
 attrs==21.2.0
     # via -r requirements/base.in
-certifi==2021.5.30
+certifi==2021.10.8
     # via requests
-cffi==1.14.6
+cffi==1.15.0
     # via cryptography
-charset-normalizer==2.0.6
+charset-normalizer==2.0.7
     # via requests
 coreapi==2.3.3
     # via drf-yasg
@@ -20,7 +20,7 @@ coreschema==0.0.4
     # via
     #   coreapi
     #   drf-yasg
-cryptography==3.4.8
+cryptography==35.0.0
     # via
     #   pyjwt
     #   social-auth-core
@@ -72,7 +72,7 @@ edx-django-release-util==1.1.0
     # via -r requirements/base.in
 edx-django-utils==4.4.0
     # via -r requirements/base.in
-idna==3.2
+idna==3.3
     # via requests
 inflection==0.5.1
     # via drf-yasg
@@ -84,7 +84,7 @@ markupsafe==2.0.1
     # via jinja2
 mysqlclient==2.0.3
     # via -r requirements/base.in
-newrelic==7.0.0.166
+newrelic==7.2.1.168
     # via edx-django-utils
 oauthlib==3.1.1
     # via
@@ -100,7 +100,7 @@ pyblake2==1.1.2
     # via -r requirements/base.in
 pycparser==2.20
     # via cffi
-pyjwt[crypto]==2.1.0
+pyjwt[crypto]==2.2.0
     # via
     #   edx-auth-backends
     #   social-auth-core
@@ -112,7 +112,7 @@ pytz==2021.3
     # via
     #   -r requirements/base.in
     #   django
-pyyaml==5.4.1
+pyyaml==6.0
     # via edx-django-release-util
 requests==2.26.0
     # via
@@ -141,7 +141,7 @@ sqlparse==0.4.2
     #   django
 stevedore==3.4.0
     # via edx-django-utils
-uritemplate==3.0.1
+uritemplate==4.1.1
     # via
     #   coreapi
     #   drf-yasg

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -15,10 +15,6 @@
 # using LTS django version
 
 
-# latest version is causing e2e failures in edx-platform.
-# See  comment.
-drf-jwt<1.19.1
-
 # elasticsearch>=7.14.0 includes breaking changes in it which caused issues in discovery upgrade process.
 # elastic search changelog: https://www.elastic.co/guide/en/enterprise-search/master/release-notes-7.14.0.html
 elasticsearch<7.14.0

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -8,15 +8,15 @@ alabaster==0.7.12
     # via sphinx
 babel==2.9.1
     # via sphinx
-certifi==2021.5.30
+certifi==2021.10.8
     # via requests
-charset-normalizer==2.0.6
+charset-normalizer==2.0.7
     # via requests
 docutils==0.17.1
     # via sphinx
 edx-sphinx-theme==3.0.0
     # via -r requirements/docs.in
-idna==3.2
+idna==3.3
     # via requests
 imagesize==1.2.0
     # via sphinx

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -12,7 +12,7 @@ asgiref==3.4.1
     # via
     #   -r requirements/test.txt
     #   django
-astroid==2.8.0
+astroid==2.8.2
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -25,12 +25,12 @@ babel==2.9.1
     # via
     #   -r requirements/docs.txt
     #   sphinx
-certifi==2021.5.30
+certifi==2021.10.8
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   requests
-cffi==1.14.6
+cffi==1.15.0
     # via
     #   -r requirements/test.txt
     #   cryptography
@@ -38,12 +38,12 @@ chardet==4.0.0
     # via
     #   -r requirements/test.txt
     #   diff-cover
-charset-normalizer==2.0.6
+charset-normalizer==2.0.7
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   requests
-click==8.0.1
+click==8.0.3
     # via
     #   -r requirements/test.txt
     #   click-log
@@ -66,11 +66,11 @@ coreschema==0.0.4
     #   -r requirements/test.txt
     #   coreapi
     #   drf-yasg
-coverage[toml]==6.0
+coverage[toml]==6.0.2
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==3.4.8
+cryptography==35.0.0
     # via
     #   -r requirements/test.txt
     #   pyjwt
@@ -82,7 +82,7 @@ defusedxml==0.7.1
     #   -r requirements/test.txt
     #   python3-openid
     #   social-auth-core
-diff-cover==6.4.1
+diff-cover==6.4.2
     # via -r requirements/test.txt
 django==3.2.8
     # via
@@ -147,11 +147,11 @@ edx-sphinx-theme==3.0.0
     # via -r requirements/docs.txt
 factory-boy==3.2.0
     # via -r requirements/test.txt
-faker==8.16.0
+faker==9.3.1
     # via
     #   -r requirements/test.txt
     #   factory-boy
-idna==3.2
+idna==3.3
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
@@ -214,7 +214,7 @@ mypy-extensions==0.4.3
     #   mypy
 mysqlclient==2.0.3
     # via -r requirements/test.txt
-newrelic==7.0.0.166
+newrelic==7.2.1.168
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -251,7 +251,7 @@ py==1.10.0
     #   pytest
 pyblake2==1.1.2
     # via -r requirements/test.txt
-pycodestyle==2.7.0
+pycodestyle==2.8.0
     # via -r requirements/test.txt
 pycparser==2.20
     # via
@@ -263,7 +263,7 @@ pygments==2.10.0
     #   -r requirements/test.txt
     #   diff-cover
     #   sphinx
-pyjwt[crypto]==2.1.0
+pyjwt[crypto]==2.2.0
     # via
     #   -r requirements/test.txt
     #   edx-auth-backends
@@ -319,7 +319,7 @@ pytz==2021.3
     #   -r requirements/test.txt
     #   babel
     #   django
-pyyaml==5.4.1
+pyyaml==6.0
     # via
     #   -r requirements/test.txt
     #   code-annotations
@@ -411,7 +411,7 @@ typing-extensions==3.10.0.2
     #   astroid
     #   mypy
     #   pylint
-uritemplate==3.0.1
+uritemplate==4.1.1
     # via
     #   -r requirements/test.txt
     #   coreapi

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-click==8.0.1
+click==8.0.3
     # via pip-tools
 pep517==0.11.0
     # via pip-tools
-pip-tools==6.3.0
+pip-tools==6.4.0
     # via -r requirements/pip-tools.in
 tomli==1.2.1
     # via pep517

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -10,23 +10,23 @@ asgiref==3.4.1
     #   django
 attrs==21.2.0
     # via -r requirements/base.txt
-boto3==1.18.54
+boto3==1.18.61
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/production.in
-botocore==1.21.54
+botocore==1.21.61
     # via
     #   boto3
     #   s3transfer
-certifi==2021.5.30
+certifi==2021.10.8
     # via
     #   -r requirements/base.txt
     #   requests
-cffi==1.14.6
+cffi==1.15.0
     # via
     #   -r requirements/base.txt
     #   cryptography
-charset-normalizer==2.0.6
+charset-normalizer==2.0.7
     # via
     #   -r requirements/base.txt
     #   requests
@@ -39,7 +39,7 @@ coreschema==0.0.4
     #   -r requirements/base.txt
     #   coreapi
     #   drf-yasg
-cryptography==3.4.8
+cryptography==35.0.0
     # via
     #   -r requirements/base.txt
     #   pyjwt
@@ -71,7 +71,7 @@ django-environ==0.7.0
     # via -r requirements/base.txt
 django-filter==21.1
     # via -r requirements/base.txt
-django-storages==1.11.1
+django-storages==1.12.1
     # via -r requirements/production.in
 django-waffle==2.2.1
     # via
@@ -106,7 +106,7 @@ greenlet==1.1.2
     # via gevent
 gunicorn==20.1.0
     # via -r requirements/production.in
-idna==3.2
+idna==3.3
     # via
     #   -r requirements/base.txt
     #   requests
@@ -132,7 +132,7 @@ markupsafe==2.0.1
     #   jinja2
 mysqlclient==2.0.3
     # via -r requirements/base.txt
-newrelic==7.0.0.166
+newrelic==7.2.1.168
     # via
     #   -r requirements/base.txt
     #   -r requirements/production.in
@@ -160,7 +160,7 @@ pycparser==2.20
     # via
     #   -r requirements/base.txt
     #   cffi
-pyjwt[crypto]==2.1.0
+pyjwt[crypto]==2.2.0
     # via
     #   -r requirements/base.txt
     #   edx-auth-backends
@@ -181,7 +181,7 @@ pytz==2021.3
     # via
     #   -r requirements/base.txt
     #   django
-pyyaml==5.4.1
+pyyaml==6.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/production.in
@@ -230,7 +230,7 @@ stevedore==3.4.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-uritemplate==3.0.1
+uritemplate==4.1.1
     # via
     #   -r requirements/base.txt
     #   coreapi

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -8,7 +8,7 @@ asgiref==3.4.1
     # via
     #   -r requirements/base.txt
     #   django
-astroid==2.8.0
+astroid==2.8.2
     # via
     #   -r requirements/test.in
     #   pylint
@@ -17,21 +17,21 @@ attrs==21.2.0
     # via
     #   -r requirements/base.txt
     #   pytest
-certifi==2021.5.30
+certifi==2021.10.8
     # via
     #   -r requirements/base.txt
     #   requests
-cffi==1.14.6
+cffi==1.15.0
     # via
     #   -r requirements/base.txt
     #   cryptography
 chardet==4.0.0
     # via diff-cover
-charset-normalizer==2.0.6
+charset-normalizer==2.0.7
     # via
     #   -r requirements/base.txt
     #   requests
-click==8.0.1
+click==8.0.3
     # via
     #   click-log
     #   code-annotations
@@ -49,11 +49,11 @@ coreschema==0.0.4
     #   -r requirements/base.txt
     #   coreapi
     #   drf-yasg
-coverage[toml]==6.0
+coverage[toml]==6.0.2
     # via
     #   -r requirements/test.in
     #   pytest-cov
-cryptography==3.4.8
+cryptography==35.0.0
     # via
     #   -r requirements/base.txt
     #   pyjwt
@@ -65,7 +65,7 @@ defusedxml==0.7.1
     #   -r requirements/base.txt
     #   python3-openid
     #   social-auth-core
-diff-cover==6.4.1
+diff-cover==6.4.2
     # via -r requirements/test.in
 django==3.2.8
     # via
@@ -121,9 +121,9 @@ edx-lint==5.2.0
     # via -r requirements/test.in
 factory-boy==3.2.0
     # via -r requirements/test.in
-faker==8.16.0
+faker==9.3.1
     # via factory-boy
-idna==3.2
+idna==3.3
     # via
     #   -r requirements/base.txt
     #   requests
@@ -164,7 +164,7 @@ mypy-extensions==0.4.3
     # via mypy
 mysqlclient==2.0.3
     # via -r requirements/base.txt
-newrelic==7.0.0.166
+newrelic==7.2.1.168
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -196,7 +196,7 @@ py==1.10.0
     # via pytest
 pyblake2==1.1.2
     # via -r requirements/base.txt
-pycodestyle==2.7.0
+pycodestyle==2.8.0
     # via -r requirements/test.in
 pycparser==2.20
     # via
@@ -204,7 +204,7 @@ pycparser==2.20
     #   cffi
 pygments==2.10.0
     # via diff-cover
-pyjwt[crypto]==2.1.0
+pyjwt[crypto]==2.2.0
     # via
     #   -r requirements/base.txt
     #   edx-auth-backends
@@ -248,7 +248,7 @@ pytz==2021.3
     # via
     #   -r requirements/base.txt
     #   django
-pyyaml==5.4.1
+pyyaml==6.0
     # via
     #   -r requirements/base.txt
     #   code-annotations
@@ -313,7 +313,7 @@ typing-extensions==3.10.0.2
     #   astroid
     #   mypy
     #   pylint
-uritemplate==3.0.1
+uritemplate==4.1.1
     # via
     #   -r requirements/base.txt
     #   coreapi


### PR DESCRIPTION
## Description

Revert changes made in #121 as django-environ has been upgraded to support Django 3.2.

## Test Instructions

Run `make easyserver`.