### PR TITLE
modified easyserver section in the Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ test: clean ## Run tests and generate coverage report
 	${VENV_BIN}/coverage xml
 	${VENV_BIN}/diff-cover coverage.xml --html-report diff-cover.html --compare-branch origin/master
 
-easyserver: dev.up dev.provision  # Start and provision a Blockstore container and run the server until CTRL-C, then stop it
+easyserver: dev.build dev.up dev.provision  # Build, Start and provision a Blockstore container and run the server until CTRL-C, then stop it
 	# Now run blockstore until the user hits CTRL-C:
 	docker-compose ${BLOCKSTORE_DOCKER_COMPOSE_OPTS} exec blockstore /blockstore/venv/bin/python /blockstore/app/manage.py runserver 0.0.0.0:18250
 	# Then stop the container:


### PR DESCRIPTION
In the `easyserver` section of the `Makefile`, it tries to start and provision the server.
This fails if the docker container does not already exist, so the first time user needs to
run 

`make dev.build`

This has been modified to build, start and provision the server so that it does not fail.

## Author Comments, Concerns, and Open Questions

If the building of blockstore container is intentionally avoided under `easyserver` in the `Makefile` then we need to modify `README.rst` to run

```
make dev.build
make easyserver 
```
In order to start `blockstore` server. 
Since it doesn't work for the first time, a new user/developer may get confused. 

## Test Instructions

- remove the `blockstore`  container.
- cd to `blockstore`
- run `make easyserver`

This should Build, Start and Provision the `blockstore` server.

Signed-off-by: Girish Joshi <girish@opencraft.com>