### PR TITLE
Remove outdated dependency constraints

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,5 +1,4 @@
 -c constraints.txt
--r github.in
 
 attrs
 pyblake2
@@ -9,6 +8,7 @@ django-waffle
 djangorestframework
 djangorestframework-expander
 django-filter
+drf-nested-routers
 edx-api-doc-tools
 edx-auth-backends
 edx-django-release-util

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -48,7 +48,7 @@ django-environ==0.8.1
     # via -r requirements/base.in
 django-filter==21.1
     # via -r requirements/base.in
-django-waffle==2.2.1
+django-waffle==2.3.0
     # via
     #   -r requirements/base.in
     #   edx-django-utils
@@ -61,15 +61,15 @@ djangorestframework==3.13.1
     #   edx-api-doc-tools
 djangorestframework-expander==0.2.3
     # via -r requirements/base.in
-drf-nested-routers @ git+https://github.com/alanjds/drf-nested-routers.git@8686392f91b114e01f3781807dea60e9a80d3e07
-    # via -r requirements/github.in
+drf-nested-routers==0.93.4
+    # via -r requirements/base.in
 drf-yasg==1.20.0
     # via edx-api-doc-tools
 edx-api-doc-tools==1.5.0
     # via -r requirements/base.in
 edx-auth-backends==4.0.1
     # via -r requirements/base.in
-edx-django-release-util==1.1.0
+edx-django-release-util==1.1.1
     # via -r requirements/base.in
 edx-django-utils==4.4.1
     # via -r requirements/base.in
@@ -147,5 +147,5 @@ uritemplate==4.1.1
     # via
     #   coreapi
     #   drf-yasg
-urllib3==1.26.7
+urllib3==1.26.8
     # via requests

--- a/requirements/docs.in
+++ b/requirements/docs.in
@@ -1,4 +1,4 @@
 -c constraints.txt
 
-Sphinx==1.6.7 ## Pinned due to bug in 1.7.0 - 1.7.1 (https://github.com/sphinx-doc/sphinx/issues/4692)
+Sphinx
 edx-sphinx-theme

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -12,7 +12,7 @@ certifi==2021.10.8
     # via requests
 charset-normalizer==2.0.10
     # via requests
-docutils==0.18.1
+docutils==0.17.1
     # via sphinx
 edx-sphinx-theme==3.0.0
     # via -r requirements/docs.in
@@ -24,27 +24,37 @@ jinja2==3.0.3
     # via sphinx
 markupsafe==2.0.1
     # via jinja2
-pygments==2.11.1
+packaging==21.3
     # via sphinx
+pygments==2.11.2
+    # via sphinx
+pyparsing==3.0.6
+    # via packaging
 pytz==2021.3
     # via babel
 requests==2.27.1
     # via sphinx
 six==1.16.0
-    # via
-    #   edx-sphinx-theme
-    #   sphinx
+    # via edx-sphinx-theme
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==1.6.7
+sphinx==4.3.2
     # via
     #   -r requirements/docs.in
     #   edx-sphinx-theme
-sphinxcontrib-serializinghtml==1.1.5
-    # via sphinxcontrib-websupport
-sphinxcontrib-websupport==1.2.4
+sphinxcontrib-applehelp==1.0.2
     # via sphinx
-urllib3==1.26.7
+sphinxcontrib-devhelp==1.0.2
+    # via sphinx
+sphinxcontrib-htmlhelp==2.0.0
+    # via sphinx
+sphinxcontrib-jsmath==1.0.1
+    # via sphinx
+sphinxcontrib-qthelp==1.0.3
+    # via sphinx
+sphinxcontrib-serializinghtml==1.1.5
+    # via sphinx
+urllib3==1.26.8
     # via requests
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/github.in
+++ b/requirements/github.in
@@ -1,3 +1,0 @@
-
-# Latest PyPi release does not have support for Django2.2, this commit from master does.
-git+https://github.com/alanjds/drf-nested-routers.git@8686392f91b114e01f3781807dea60e9a80d3e07#egg=drf-nested-routers==0.91

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -12,7 +12,7 @@ asgiref==3.4.1
     # via
     #   -r requirements/test.txt
     #   django
-astroid==2.9.2
+astroid==2.9.3
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -111,7 +111,7 @@ django-environ==0.8.1
     # via -r requirements/test.txt
 django-filter==21.1
     # via -r requirements/test.txt
-django-waffle==2.2.1
+django-waffle==2.3.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -124,11 +124,11 @@ djangorestframework==3.13.1
     #   edx-api-doc-tools
 djangorestframework-expander==0.2.3
     # via -r requirements/test.txt
-docutils==0.18.1
+docutils==0.17.1
     # via
     #   -r requirements/docs.txt
     #   sphinx
-drf-nested-routers @ git+https://github.com/alanjds/drf-nested-routers.git@8686392f91b114e01f3781807dea60e9a80d3e07
+drf-nested-routers==0.93.4
     # via -r requirements/test.txt
 drf-yasg==1.20.0
     # via
@@ -138,7 +138,7 @@ edx-api-doc-tools==1.5.0
     # via -r requirements/test.txt
 edx-auth-backends==4.0.1
     # via -r requirements/test.txt
-edx-django-release-util==1.1.0
+edx-django-release-util==1.1.1
     # via -r requirements/test.txt
 edx-django-utils==4.4.1
     # via -r requirements/test.txt
@@ -198,7 +198,7 @@ mccabe==0.6.1
     # via
     #   -r requirements/test.txt
     #   pylint
-mypy==0.930
+mypy==0.931
     # via -r requirements/test.txt
 mypy-extensions==0.4.3
     # via
@@ -217,9 +217,11 @@ oauthlib==3.1.1
     #   social-auth-core
 packaging==21.3
     # via
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   drf-yasg
     #   pytest
+    #   sphinx
 pbr==5.8.0
     # via
     #   -r requirements/test.txt
@@ -249,7 +251,7 @@ pycparser==2.21
     # via
     #   -r requirements/test.txt
     #   cffi
-pygments==2.11.1
+pygments==2.11.2
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
@@ -282,6 +284,7 @@ pylint-plugin-utils==0.7
     #   pylint-django
 pyparsing==3.0.6
     # via
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   packaging
 pytest==6.2.5
@@ -347,7 +350,6 @@ six==1.16.0
     #   edx-lint
     #   edx-sphinx-theme
     #   python-dateutil
-    #   sphinx
 snowballstemmer==2.2.0
     # via
     #   -r requirements/docs.txt
@@ -361,15 +363,31 @@ social-auth-core==4.1.0
     #   -r requirements/test.txt
     #   edx-auth-backends
     #   social-auth-app-django
-sphinx==1.6.7
+sphinx==4.3.2
     # via
     #   -r requirements/docs.txt
     #   edx-sphinx-theme
-sphinxcontrib-serializinghtml==1.1.5
+sphinxcontrib-applehelp==1.0.2
     # via
     #   -r requirements/docs.txt
-    #   sphinxcontrib-websupport
-sphinxcontrib-websupport==1.2.4
+    #   sphinx
+sphinxcontrib-devhelp==1.0.2
+    # via
+    #   -r requirements/docs.txt
+    #   sphinx
+sphinxcontrib-htmlhelp==2.0.0
+    # via
+    #   -r requirements/docs.txt
+    #   sphinx
+sphinxcontrib-jsmath==1.0.1
+    # via
+    #   -r requirements/docs.txt
+    #   sphinx
+sphinxcontrib-qthelp==1.0.3
+    # via
+    #   -r requirements/docs.txt
+    #   sphinx
+sphinxcontrib-serializinghtml==1.1.5
     # via
     #   -r requirements/docs.txt
     #   sphinx
@@ -409,7 +427,7 @@ uritemplate==4.1.1
     #   -r requirements/test.txt
     #   coreapi
     #   drf-yasg
-urllib3==1.26.7
+urllib3==1.26.8
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -10,11 +10,11 @@ asgiref==3.4.1
     #   django
 attrs==21.4.0
     # via -r requirements/base.txt
-boto3==1.20.29
+boto3==1.20.32
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/production.in
-botocore==1.23.29
+botocore==1.23.33
     # via
     #   boto3
     #   s3transfer
@@ -74,7 +74,7 @@ django-filter==21.1
     # via -r requirements/base.txt
 django-storages==1.12.3
     # via -r requirements/production.in
-django-waffle==2.2.1
+django-waffle==2.3.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -87,7 +87,7 @@ djangorestframework==3.13.1
     #   edx-api-doc-tools
 djangorestframework-expander==0.2.3
     # via -r requirements/base.txt
-drf-nested-routers @ git+https://github.com/alanjds/drf-nested-routers.git@8686392f91b114e01f3781807dea60e9a80d3e07
+drf-nested-routers==0.93.4
     # via -r requirements/base.txt
 drf-yasg==1.20.0
     # via
@@ -97,7 +97,7 @@ edx-api-doc-tools==1.5.0
     # via -r requirements/base.txt
 edx-auth-backends==4.0.1
     # via -r requirements/base.txt
-edx-django-release-util==1.1.0
+edx-django-release-util==1.1.1
     # via -r requirements/base.txt
 edx-django-utils==4.4.1
     # via -r requirements/base.txt
@@ -237,7 +237,7 @@ uritemplate==4.1.1
     #   -r requirements/base.txt
     #   coreapi
     #   drf-yasg
-urllib3==1.26.7
+urllib3==1.26.8
     # via
     #   -r requirements/base.txt
     #   botocore

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -8,7 +8,7 @@ asgiref==3.4.1
     # via
     #   -r requirements/base.txt
     #   django
-astroid==2.9.2
+astroid==2.9.3
     # via
     #   -r requirements/test.in
     #   pylint
@@ -91,7 +91,7 @@ django-environ==0.8.1
     # via -r requirements/base.txt
 django-filter==21.1
     # via -r requirements/base.txt
-django-waffle==2.2.1
+django-waffle==2.3.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -104,7 +104,7 @@ djangorestframework==3.13.1
     #   edx-api-doc-tools
 djangorestframework-expander==0.2.3
     # via -r requirements/base.txt
-drf-nested-routers @ git+https://github.com/alanjds/drf-nested-routers.git@8686392f91b114e01f3781807dea60e9a80d3e07
+drf-nested-routers==0.93.4
     # via -r requirements/base.txt
 drf-yasg==1.20.0
     # via
@@ -114,7 +114,7 @@ edx-api-doc-tools==1.5.0
     # via -r requirements/base.txt
 edx-auth-backends==4.0.1
     # via -r requirements/base.txt
-edx-django-release-util==1.1.0
+edx-django-release-util==1.1.1
     # via -r requirements/base.txt
 edx-django-utils==4.4.1
     # via -r requirements/base.txt
@@ -154,7 +154,7 @@ markupsafe==2.0.1
     #   jinja2
 mccabe==0.6.1
     # via pylint
-mypy==0.930
+mypy==0.931
     # via -r requirements/test.in
 mypy-extensions==0.4.3
     # via mypy
@@ -198,7 +198,7 @@ pycparser==2.21
     # via
     #   -r requirements/base.txt
     #   cffi
-pygments==2.11.1
+pygments==2.11.2
     # via diff-cover
 pyjwt[crypto]==2.3.0
     # via
@@ -316,7 +316,7 @@ uritemplate==4.1.1
     #   -r requirements/base.txt
     #   coreapi
     #   drf-yasg
-urllib3==1.26.7
+urllib3==1.26.8
     # via
     #   -r requirements/base.txt
     #   requests


### PR DESCRIPTION
## Description

Inspired by a recent Django 3.2 upgrade talk, I looked at our TNL-owned repos for requirement constraints. This repo has two requirement constraints that no longer need to be present, due to recent code releases of the packages. Removing these constraints will make it easier on the Django 3.2 upgrade team to upgrade the whole of Open edX platform.

## Test Instructions

Verify the CI passes.

## TODOs
If anything isn't yet done, list it here
- [ ] Squash before merging
