### PR TITLE
chore: remove unused djangoresframework-expander library

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -6,7 +6,6 @@ django
 django-environ
 django-waffle
 djangorestframework
-djangorestframework-expander
 django-filter
 drf-nested-routers
 edx-api-doc-tools

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -55,12 +55,9 @@ django-waffle==2.3.0
 djangorestframework==3.13.1
     # via
     #   -r requirements/base.in
-    #   djangorestframework-expander
     #   drf-nested-routers
     #   drf-yasg
     #   edx-api-doc-tools
-djangorestframework-expander==0.2.3
-    # via -r requirements/base.in
 drf-nested-routers==0.93.4
     # via -r requirements/base.in
 drf-yasg==1.20.0

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -118,12 +118,9 @@ django-waffle==2.3.0
 djangorestframework==3.13.1
     # via
     #   -r requirements/test.txt
-    #   djangorestframework-expander
     #   drf-nested-routers
     #   drf-yasg
     #   edx-api-doc-tools
-djangorestframework-expander==0.2.3
-    # via -r requirements/test.txt
 docutils==0.17.1
     # via
     #   -r requirements/docs.txt

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -81,12 +81,9 @@ django-waffle==2.3.0
 djangorestframework==3.13.1
     # via
     #   -r requirements/base.txt
-    #   djangorestframework-expander
     #   drf-nested-routers
     #   drf-yasg
     #   edx-api-doc-tools
-djangorestframework-expander==0.2.3
-    # via -r requirements/base.txt
 drf-nested-routers==0.93.4
     # via -r requirements/base.txt
 drf-yasg==1.20.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -98,12 +98,9 @@ django-waffle==2.3.0
 djangorestframework==3.13.1
     # via
     #   -r requirements/base.txt
-    #   djangorestframework-expander
     #   drf-nested-routers
     #   drf-yasg
     #   edx-api-doc-tools
-djangorestframework-expander==0.2.3
-    # via -r requirements/base.txt
 drf-nested-routers==0.93.4
     # via -r requirements/base.txt
 drf-yasg==1.20.0


### PR DESCRIPTION
## Description

This PR removes `djangoresframework-expander` library that's not being used.

## Test Instructions

Empty searches:
- expander
- ExpanderSerializerMixin
- djangorestframework-expander