### PR TITLE
Manually upgrade all requirements to fix pip/pip-tools incompatibility.

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,7 +12,7 @@ certifi==2021.10.8
     # via requests
 cffi==1.15.0
     # via cryptography
-charset-normalizer==2.0.11
+charset-normalizer==2.0.12
     # via requests
 coreapi==2.3.3
     # via drf-yasg
@@ -62,7 +62,7 @@ drf-nested-routers==0.93.4
     # via -r requirements/base.in
 drf-yasg==1.20.0
     # via edx-api-doc-tools
-edx-api-doc-tools==1.5.0
+edx-api-doc-tools==1.6.0
     # via -r requirements/base.in
 edx-auth-backends==4.1.0
     # via -r requirements/base.in
@@ -90,7 +90,7 @@ oauthlib==3.2.0
     #   social-auth-core
 packaging==21.3
     # via drf-yasg
-pbr==5.8.0
+pbr==5.8.1
     # via stevedore
 psutil==5.9.0
     # via edx-django-utils
@@ -120,9 +120,9 @@ requests==2.27.1
     #   social-auth-core
 requests-oauthlib==1.3.1
     # via social-auth-core
-ruamel.yaml==0.17.20
+ruamel-yaml==0.17.21
     # via drf-yasg
-ruamel.yaml.clib==0.2.6
+ruamel-yaml-clib==0.2.6
     # via ruamel.yaml
 six==1.16.0
     # via

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -10,7 +10,7 @@ babel==2.9.1
     # via sphinx
 certifi==2021.10.8
     # via requests
-charset-normalizer==2.0.11
+charset-normalizer==2.0.12
     # via requests
 docutils==0.17.1
     # via sphinx
@@ -20,7 +20,7 @@ idna==3.3
     # via requests
 imagesize==1.3.0
     # via sphinx
-importlib-metadata==4.10.1
+importlib-metadata==4.11.1
     # via sphinx
 jinja2==3.0.3
     # via sphinx

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -38,7 +38,7 @@ chardet==4.0.0
     # via
     #   -r requirements/test.txt
     #   diff-cover
-charset-normalizer==2.0.11
+charset-normalizer==2.0.12
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
@@ -53,7 +53,7 @@ click-log==0.3.2
     # via
     #   -r requirements/test.txt
     #   edx-lint
-code-annotations==1.2.0
+code-annotations==1.3.0
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -131,7 +131,7 @@ drf-yasg==1.20.0
     # via
     #   -r requirements/test.txt
     #   edx-api-doc-tools
-edx-api-doc-tools==1.5.0
+edx-api-doc-tools==1.6.0
     # via -r requirements/test.txt
 edx-auth-backends==4.1.0
     # via -r requirements/test.txt
@@ -145,7 +145,7 @@ edx-sphinx-theme==3.0.0
     # via -r requirements/docs.txt
 factory-boy==3.2.1
     # via -r requirements/test.txt
-faker==12.0.0
+faker==13.0.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -158,7 +158,7 @@ imagesize==1.3.0
     # via
     #   -r requirements/docs.txt
     #   sphinx
-importlib-metadata==4.10.1
+importlib-metadata==4.11.1
     # via
     #   -r requirements/docs.txt
     #   sphinx
@@ -223,11 +223,11 @@ packaging==21.3
     #   drf-yasg
     #   pytest
     #   sphinx
-pbr==5.8.0
+pbr==5.8.1
     # via
     #   -r requirements/test.txt
     #   stevedore
-platformdirs==2.4.1
+platformdirs==2.5.0
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -274,7 +274,7 @@ pylint-celery==0.3
     # via
     #   -r requirements/test.txt
     #   edx-lint
-pylint-django==2.5.0
+pylint-django==2.5.1
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -288,7 +288,7 @@ pyparsing==3.0.7
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   packaging
-pytest==6.2.5
+pytest==7.0.1
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -301,7 +301,7 @@ python-dateutil==2.8.2
     # via
     #   -r requirements/test.txt
     #   faker
-python-slugify==5.0.2
+python-slugify==6.0.1
     # via
     #   -r requirements/test.txt
     #   code-annotations
@@ -333,14 +333,14 @@ requests-oauthlib==1.3.1
     # via
     #   -r requirements/test.txt
     #   social-auth-core
-ruamel.yaml==0.17.20
-    # via
-    #   -r requirements/test.txt
-    #   drf-yasg
-ruamel.yaml.clib==0.2.6
-    # via
-    #   -r requirements/test.txt
-    #   ruamel.yaml
+ruamel-yaml==0.17.21
+    # via -r requirements/test.txt
+ruamel-yaml-clib==0.2.6
+    # via -r requirements/test.txt
+ruamel-yaml==0.17.21
+    # via drf-yasg
+ruamel-yaml-clib==0.2.6
+    # via ruamel-yaml
 six==1.16.0
     # via
     #   -r requirements/docs.txt
@@ -410,13 +410,13 @@ toml==0.10.2
     # via
     #   -r requirements/test.txt
     #   pylint
-    #   pytest
-tomli==2.0.0
+tomli==2.0.1
     # via
     #   -r requirements/test.txt
     #   coverage
     #   mypy
-typing-extensions==4.0.1
+    #   pytest
+typing-extensions==4.1.1
     # via
     #   -r requirements/test.txt
     #   astroid

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -8,9 +8,9 @@ click==8.0.3
     # via pip-tools
 pep517==0.12.0
     # via pip-tools
-pip-tools==6.4.0
+pip-tools==6.5.1
     # via -r requirements/pip-tools.in
-tomli==2.0.0
+tomli==2.0.1
     # via pep517
 wheel==0.37.1
     # via pip-tools

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -10,11 +10,11 @@ asgiref==3.5.0
     #   django
 attrs==21.4.0
     # via -r requirements/base.txt
-boto3==1.20.47
+boto3==1.21.1
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/production.in
-botocore==1.23.47
+botocore==1.24.1
     # via
     #   boto3
     #   s3transfer
@@ -26,7 +26,7 @@ cffi==1.15.0
     # via
     #   -r requirements/base.txt
     #   cryptography
-charset-normalizer==2.0.11
+charset-normalizer==2.0.12
     # via
     #   -r requirements/base.txt
     #   requests
@@ -90,7 +90,7 @@ drf-yasg==1.20.0
     # via
     #   -r requirements/base.txt
     #   edx-api-doc-tools
-edx-api-doc-tools==1.5.0
+edx-api-doc-tools==1.6.0
     # via -r requirements/base.txt
 edx-auth-backends==4.1.0
     # via -r requirements/base.txt
@@ -144,7 +144,7 @@ packaging==21.3
     # via
     #   -r requirements/base.txt
     #   drf-yasg
-pbr==5.8.0
+pbr==5.8.1
     # via
     #   -r requirements/base.txt
     #   stevedore
@@ -195,13 +195,15 @@ requests-oauthlib==1.3.1
     # via
     #   -r requirements/base.txt
     #   social-auth-core
-ruamel.yaml==0.17.20
+ruamel-yaml==0.17.21
+    # via -r requirements/base.txt
+ruamel-yaml-clib==0.2.6
+    # via -r requirements/base.txt
+ruamel-yaml==0.17.21
+    # via drf-yasg
+ruamel-yaml-clib==0.2.6
     # via
-    #   -r requirements/base.txt
-    #   drf-yasg
-ruamel.yaml.clib==0.2.6
-    # via
-    #   -r requirements/base.txt
+    #   ruamel-yaml
     #   ruamel.yaml
 s3transfer==0.5.1
     # via boto3
@@ -239,9 +241,9 @@ urllib3==1.26.8
     #   -r requirements/base.txt
     #   botocore
     #   requests
-zope.event==4.5.0
+zope-event==4.5.0
     # via gevent
-zope.interface==5.4.0
+zope-interface==5.4.0
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -27,7 +27,7 @@ cffi==1.15.0
     #   cryptography
 chardet==4.0.0
     # via diff-cover
-charset-normalizer==2.0.11
+charset-normalizer==2.0.12
     # via
     #   -r requirements/base.txt
     #   requests
@@ -38,7 +38,7 @@ click==8.0.3
     #   edx-lint
 click-log==0.3.2
     # via edx-lint
-code-annotations==1.2.0
+code-annotations==1.3.0
     # via edx-lint
 coreapi==2.3.3
     # via
@@ -107,7 +107,7 @@ drf-yasg==1.20.0
     # via
     #   -r requirements/base.txt
     #   edx-api-doc-tools
-edx-api-doc-tools==1.5.0
+edx-api-doc-tools==1.6.0
     # via -r requirements/base.txt
 edx-auth-backends==4.1.0
     # via -r requirements/base.txt
@@ -119,7 +119,7 @@ edx-lint==5.2.1
     # via -r requirements/test.in
 factory-boy==3.2.1
     # via -r requirements/test.in
-faker==12.0.0
+faker==13.0.0
     # via factory-boy
 idna==3.3
     # via
@@ -171,11 +171,11 @@ packaging==21.3
     #   -r requirements/base.txt
     #   drf-yasg
     #   pytest
-pbr==5.8.0
+pbr==5.8.1
     # via
     #   -r requirements/base.txt
     #   stevedore
-platformdirs==2.4.1
+platformdirs==2.5.0
     # via pylint
 pluggy==1.0.0
     # via
@@ -210,7 +210,7 @@ pylint==2.12.2
     #   pylint-plugin-utils
 pylint-celery==0.3
     # via edx-lint
-pylint-django==2.5.0
+pylint-django==2.5.1
     # via edx-lint
 pylint-plugin-utils==0.7
     # via
@@ -220,7 +220,7 @@ pyparsing==3.0.7
     # via
     #   -r requirements/base.txt
     #   packaging
-pytest==6.2.5
+pytest==7.0.1
     # via
     #   -r requirements/test.in
     #   pytest-cov
@@ -231,7 +231,7 @@ pytest-django==4.5.2
     # via -r requirements/test.in
 python-dateutil==2.8.2
     # via faker
-python-slugify==5.0.2
+python-slugify==6.0.1
     # via code-annotations
 python3-openid==3.2.0
     # via
@@ -257,13 +257,15 @@ requests-oauthlib==1.3.1
     # via
     #   -r requirements/base.txt
     #   social-auth-core
-ruamel.yaml==0.17.20
+ruamel-yaml==0.17.21
+    # via -r requirements/base.txt
+ruamel-yaml-clib==0.2.6
+    # via -r requirements/base.txt
+ruamel-yaml==0.17.21
+    # via drf-yasg
+ruamel-yaml-clib==0.2.6
     # via
-    #   -r requirements/base.txt
-    #   drf-yasg
-ruamel.yaml.clib==0.2.6
-    # via
-    #   -r requirements/base.txt
+    #   ruamel-yaml
     #   ruamel.yaml
 six==1.16.0
     # via
@@ -294,14 +296,13 @@ stevedore==3.5.0
 text-unidecode==1.3
     # via python-slugify
 toml==0.10.2
-    # via
-    #   pylint
-    #   pytest
-tomli==2.0.0
+    # via pylint
+tomli==2.0.1
     # via
     #   coverage
     #   mypy
-typing-extensions==4.0.1
+    #   pytest
+typing-extensions==4.1.1
     # via
     #   astroid
     #   mypy


### PR DESCRIPTION
## Description

Manually upgrade all requirements locally to fix pip/pip-tools incompatibility.
Steps I took:
- Manually edited the pip-tools.txt file, changing this line: `pip-tools==6.5.0`
- Activated Python3 virtualenv.
- `make requirements`
- `make upgrade`
