### PR TITLE
[BD-14] fix: allows bundle storage kwargs setting to be optional

### DIFF
--- a/blockstore/__init__.py
+++ b/blockstore/__init__.py
@@ -2,4 +2,4 @@
 Blockstore is a system for storing educational content.
 """
 
-__version__ = '1.2.0'
+__version__ = '1.2.1'

--- a/blockstore/apps/bundles/storage.py
+++ b/blockstore/apps/bundles/storage.py
@@ -96,7 +96,7 @@ class LongLivedSignedUrlStorage(Storage):  # pylint: disable=abstract-method
         # All other S3 settings will be pulled in automatically from Django settings
         # (such as AWS_QUERYSTRING_EXPIRE and AWS_STORAGE_BUCKET_NAME).
         s3_backend_args = dict(
-            **settings.BUNDLE_ASSET_STORAGE_SETTINGS['STORAGE_KWARGS']
+            **settings.BUNDLE_ASSET_STORAGE_SETTINGS.get('STORAGE_KWARGS', {})
         )
         s3_backend_args.update(
             access_key=key,

--- a/blockstore/apps/bundles/tests/test_storage.py
+++ b/blockstore/apps/bundles/tests/test_storage.py
@@ -3,6 +3,7 @@ Tests for storage classes in storage.py
 """
 from unittest.mock import patch, MagicMock
 
+from django.conf import settings
 from django.test import override_settings
 import pytest
 
@@ -13,11 +14,11 @@ class _MockS3backend:
     """
     A fake replacment for S3Boto3Backend in these tests.
     """
-    def __init__(self, **settings):
-        self.access_key = settings["access_key"]
-        self.secret_key = settings["secret_key"]
-        self.bucket_name = settings["bucket_name"]
-        self.location = settings["location"]
+    def __init__(self, **kwargs):
+        self.access_key = kwargs.get("access_key", getattr(settings, 'AWS_S3_ACCESS_KEY_ID', None))
+        self.secret_key = kwargs.get("secret_key", getattr(settings, 'AWS_S3_SECRET_ACCESS_KEY', None))
+        self.bucket_name = kwargs.get("bucket_name", getattr(settings, 'AWS_STORAGE_BUCKET_NAME', None))
+        self.location = kwargs.get("location", getattr(settings, 'AWS_LOCATION', None))
 
     def url(self, name):
         return f"https://{self.bucket_name}/{self.location}{name}"
@@ -38,6 +39,17 @@ _patch_default_storage = patch.object(
 )
 _patch_get_storage_class = patch.object(
     storage_module, 'get_storage_class', autospec=True, side_effect=get_storage_class
+)
+_patch_storage_class = override_settings(
+    AWS_LOCATION="s3/",
+    AWS_STORAGE_BUCKET_NAME="example-bucket",
+    AWS_S3_ACCESS_KEY_ID="another_key",
+    AWS_S3_SECRET_ACCESS_KEY="another_secret",
+    BUNDLE_ASSET_URL_STORAGE_KEY="a-key",
+    BUNDLE_ASSET_URL_STORAGE_SECRET="a-secret",
+    BUNDLE_ASSET_STORAGE_SETTINGS={
+        'STORAGE_CLASS': 'storages.backends.s3boto3.S3Boto3Storage',
+    },
 )
 _patch_s3_long_lived_credentials = override_settings(
     BUNDLE_ASSET_URL_STORAGE_KEY="a-key", BUNDLE_ASSET_URL_STORAGE_SECRET="a-secret",
@@ -78,6 +90,27 @@ def test_asset_storage_long_lived_urls_disabled(mock_default_storage):
     mock_default_storage.url.assert_called_once_with('abc')
     mock_default_storage.listdir.assert_called_once_with('123')
     mock_default_storage.get_accessed_time.assert_called_once_with('xyz')
+
+
+@_patch_storage_class
+@_patch_get_storage_class
+@_patch_default_storage
+def test_asset_storage_class(mock_default_storage, *_args):
+    """
+    Test that overriding the storage class works without the optional setting storage kwargs.
+    """
+    backend = storage_module.AssetStorage()
+    assert isinstance(backend.url_backend, storage_module.LongLivedSignedUrlStorage)
+    assert backend.url_backend.s3_backend.access_key == "a-key"
+    assert backend.url_backend.s3_backend.secret_key == "a-secret"
+    assert backend.url_backend.s3_backend.bucket_name == "example-bucket"
+    assert backend.url_backend.s3_backend.location == "s3/"
+    assert backend.asset_backend.access_key == "another_key"
+    assert backend.asset_backend.secret_key == "another_secret"
+    assert backend.asset_backend.bucket_name == "example-bucket"
+    assert backend.asset_backend.location == "s3/"
+    assert backend.url('abc') == "https://example-bucket/s3/abc"
+    assert not mock_default_storage.url.called
 
 
 @_patch_s3_long_lived_credentials


### PR DESCRIPTION
## Description

Fixes configuration bug introduced by https://github.com/openedx/blockstore/pull/149, see https://github.com/openedx/blockstore/pull/149#issuecomment-1088948641

The docstring for the added `settings.BUNDLE_ASSET_STORAGE_SETTINGS ` declared that the contained `STORAGE_KWARGS` dict was optional. However, the code failed if the dict was not specified.

This change remedies this bug, and adds a test to verify the change.

## Author Comments, Concerns, and Open Questions

Note that if `settings.BUNDLE_ASSET_STORAGE_SETTINGS == {'STORAGE_CLASS': 'storages.backends.s3boto3.S3Boto3Storage'}` (i.e. `settings.BUNDLE_ASSET_STORAGE_SETTINGS['STORAGE_KWARGS']` is not specified), then top-level settings are used instead for the bucket name, location, etc. See [S3 Django Storage docs](https://django-storages.readthedocs.io/en/latest/backends/amazon-S3.html#settings) for details.

## Test Instructions

The manual test instructions described here are duplicated by the added test.

1. Set up blockstore as an IDA (see [README](https://github.com/openedx/blockstore#using-with-docker-devstack)).
2. Configure the IDA to use long-lived S3 storage for asset URLs by setting: 
   ```
   AWS_LOCATION: 'path for bundle assets goes here (optional)'
   AWS_STORAGE_BUCKET_NAME: 'bucket name goes here'
   AWS_S3_ACCESS_KEY_ID: 'AWS key ID for asset storage goes here'
   AWS_S3_SECRET_ACCESS_KEY: 'AWS secret key for asset storage goes here'
   BUNDLE_ASSET_URL_STORAGE_KEY: 'AWS key ID for long-lived URLs goes here'
   BUNDLE_ASSSET_URL_STORAGE_SECRET: 'AWS secret key for long-lived URLs goes here'
   BUNDLE_ASSET_STORAGE_SETTINGS: {
      'STORAGE_CLASS': 'storages.backends.s3boto3.S3Boto3Storage',
   }
   ```

## TODOs
If anything isn't yet done, list it here
- [ ] Squash before merging