### PR TITLE
[BD-14] test: adds storage config logging and improves tests

### DIFF
--- a/blockstore/__init__.py
+++ b/blockstore/__init__.py
@@ -2,4 +2,4 @@
 Blockstore is a system for storing educational content.
 """
 
-__version__ = '1.2.1'
+__version__ = '1.2.2'

--- a/blockstore/apps/bundles/store.py
+++ b/blockstore/apps/bundles/store.py
@@ -284,6 +284,7 @@ class SnapshotRepo:
     """
     def __init__(self, storage=None):
         self.storage = storage or default_asset_storage
+        logger.info('BLOCKSTORE: SnapshotRepo.storage=%s', self.storage)
 
     def get(self, bundle_uuid: UUID, snapshot_digest: bytes) -> Snapshot:
         """


### PR DESCRIPTION
## Description

Adds info-level logging to help debug issues with blockstore storage configuration.
Improves the storage configuration tests to further clarify effects of different configurations.

## Author Comments, Concerns, and Open Questions

No functionality has been changed here -- it's just logging and tests.

We test the blockstore storage configuration options quite thoroughly -- the test most relevant to edx.org's configured deployment of blockstore-as-an-app is: [`test_asset_storage_long_lived_urls_enabled`](https://github.com/open-craft/blockstore/blob/jill/blockstore-storage-logging/blockstore/apps/bundles/tests/test_storage.py#L148-L182). It demonstrates [these storage settings](https://github.com/open-craft/blockstore/blob/jill/blockstore-storage-logging/blockstore/apps/bundles/tests/test_storage.py#L54-L71), which show how top-level `AWS_*` variables are overridden by `BUNDLE_ASSET_*` variables.

## Test Instructions

TODO -- on edx-platform OSPR

## TODOs

- [ ] Squash before merging
- [ ] Tag new release `1.2.2` after merging.
