### PR TITLE
[BD-14] fix: remove refrence to access key in logging

### DIFF
--- a/blockstore/apps/bundles/storage.py
+++ b/blockstore/apps/bundles/storage.py
@@ -199,10 +199,9 @@ class AssetStorage(Storage):
 
     def __repr__(self):
         """Used to log details about the configured storage backend"""
-        return 'asset_backend={}(bucket_name={}, access_key={}), url_backend={})'.format(
+        return 'asset_backend={}(bucket_name={}), url_backend={})'.format(
             str(self.asset_backend),
             getattr(self.asset_backend, 'bucket_name', None),
-            getattr(self.asset_backend, 'access_key', 'NOT SET')[-8:],
             str(self.url_backend),
         )
 


### PR DESCRIPTION
## Description

So the addition of logging is great, but we are not setting the access key in edx-platform build since we use IAM roles and not key, and therefore the getattr call is erroring. We removed any reference to the access key. 

## Author Comments, Concerns, and Open Questions

## Test Instructions

TODO: Include detailed instructions that explain how your reviewers can manually test this code.

## TODOs
If anything isn't yet done, list it here
- [ ] Squash before merging

