### PR TITLE
[BD-14] fix: remove refrence to access key in logging

### DIFF
--- a/blockstore/__init__.py
+++ b/blockstore/__init__.py
@@ -2,4 +2,4 @@
 Blockstore is a system for storing educational content.
 """
 
-__version__ = '1.2.2'
+__version__ = '1.2.3'

--- a/blockstore/apps/bundles/storage.py
+++ b/blockstore/apps/bundles/storage.py
@@ -199,10 +199,9 @@ class AssetStorage(Storage):
 
     def __repr__(self):
         """Used to log details about the configured storage backend"""
-        return 'asset_backend={}(bucket_name={}, access_key={}), url_backend={})'.format(
+        return 'asset_backend={}(bucket_name={}), url_backend={})'.format(
             str(self.asset_backend),
             getattr(self.asset_backend, 'bucket_name', None),
-            getattr(self.asset_backend, 'access_key', 'NOT SET')[-8:],
             str(self.url_backend),
         )
 

--- a/blockstore/apps/bundles/storage.py
+++ b/blockstore/apps/bundles/storage.py
@@ -115,10 +115,9 @@ class LongLivedSignedUrlStorage(Storage):  # pylint: disable=abstract-method
         return self.s3_backend.url(name)
 
     def __repr__(self):
-        return '{}(bucket_name={}, access_key={})'.format(
+        return '{}(bucket_name={})'.format(
             str(self.s3_backend),
             getattr(self.s3_backend, 'bucket_name', None),
-            getattr(self.s3_backend, 'access_key', 'NOT SET')[-8:],
         )
 
 

--- a/blockstore/apps/bundles/tests/test_storage.py
+++ b/blockstore/apps/bundles/tests/test_storage.py
@@ -15,8 +15,8 @@ class _MockS3backend:
     A fake replacment for S3Boto3Backend in these tests.
     """
     def __init__(self, **kwargs):
-        self.access_key = kwargs.get("access_key", getattr(settings, 'AWS_S3_ACCESS_KEY_ID', None))
-        self.secret_key = kwargs.get("secret_key", getattr(settings, 'AWS_S3_SECRET_ACCESS_KEY', None))
+        self.access_key = kwargs.get("access_key", getattr(settings, 'AWS_ACCESS_KEY_ID', None))
+        self.secret_key = kwargs.get("secret_key", getattr(settings, 'AWS_SECRET_ACCESS_KEY', None))
         self.bucket_name = kwargs.get("bucket_name", getattr(settings, 'AWS_STORAGE_BUCKET_NAME', None))
         self.location = kwargs.get("location", getattr(settings, 'AWS_LOCATION', None))
 
@@ -43,8 +43,8 @@ _patch_get_storage_class = patch.object(
 _patch_storage_class = override_settings(
     AWS_LOCATION="default/",
     AWS_STORAGE_BUCKET_NAME="default-bucket",
-    AWS_S3_ACCESS_KEY_ID="default_key",
-    AWS_S3_SECRET_ACCESS_KEY="default_secret",
+    AWS_ACCESS_KEY_ID="default_key",
+    AWS_SECRET_ACCESS_KEY="default_secret",
     BUNDLE_ASSET_URL_STORAGE_KEY="long-lived-key",
     BUNDLE_ASSET_URL_STORAGE_SECRET="long-lived-secret",
     BUNDLE_ASSET_STORAGE_SETTINGS={
@@ -55,8 +55,8 @@ _patch_storage_class = override_settings(
 _patch_s3_long_lived_credentials = override_settings(
     AWS_LOCATION="default/",
     AWS_STORAGE_BUCKET_NAME="default-bucket",
-    AWS_S3_ACCESS_KEY_ID="default_key",
-    AWS_S3_SECRET_ACCESS_KEY="default_secret",
+    AWS_ACCESS_KEY_ID="default_key",
+    AWS_SECRET_ACCESS_KEY="default_secret",
     BUNDLE_ASSET_URL_STORAGE_KEY="long-lived-key",
     BUNDLE_ASSET_URL_STORAGE_SECRET="long-lived-secret",
     BUNDLE_ASSET_STORAGE_SETTINGS={
@@ -70,8 +70,8 @@ _patch_s3_long_lived_credentials = override_settings(
 _patch_s3_credentials = override_settings(
     AWS_LOCATION="default/",
     AWS_STORAGE_BUCKET_NAME="default-bucket",
-    AWS_S3_ACCESS_KEY_ID="default_key",
-    AWS_S3_SECRET_ACCESS_KEY="default_secret",
+    AWS_ACCESS_KEY_ID="default_key",
+    AWS_SECRET_ACCESS_KEY="default_secret",
     BUNDLE_ASSET_STORAGE_SETTINGS={
         'STORAGE_CLASS': 'storages.backends.some.other.backend',
         'STORAGE_KWARGS': {


### PR DESCRIPTION
## Description

Updates https://github.com/openedx/blockstore/pull/183 to remove the other reference to `access_key` in logging,
and to fix the tests so they're no longer breaking, and also better match edX's blockstore storage config.

## Author Comments, Concerns, and Open Questions

## Test Instructions

TODO: Include detailed instructions that explain how your reviewers can manually test this code.

## TODOs
If anything isn't yet done, list it here
- [ ] Squash before merging
