### PR TITLE
build: include sub-packages in wheel (and bump to 1.2.5)

### DIFF
--- a/blockstore/__init__.py
+++ b/blockstore/__init__.py
@@ -2,4 +2,4 @@
 Blockstore is a system for storing educational content.
 """
 
-__version__ = '1.2.4'
+__version__ = '1.2.5'

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import os
 import re
 import sys
 
-from setuptools import setup
+from setuptools import find_packages, setup
 
 
 def get_version(*file_paths):
@@ -70,9 +70,7 @@ setup(
     description="""Blockstore is a storage system for learning content in Open edX.""",
     long_description=README + '\n\n' + CHANGELOG,
     url='https://github.com/openedx/blockstore',
-    packages=[
-        'blockstore',
-    ],
+    packages=find_packages(include=["blockstore", "blockstore.*"], exclude=["*tests"]),
     include_package_data=True,
     install_requires=load_requirements('requirements/base.in'),
     python_requires=">=3.8",


### PR DESCRIPTION
## Description

This repository's setup.py was configured
such that only the root Python package (`blockstore`)
was included, not sub-packages (`blockstore.apps`, etc.).
This commit fixes that by using `find_packages(...)`.

A similar fix was made to the cookiecutter repository
here: https://github.com/openedx/edx-cookiecutters/pull/257

The implication of the misconfiguration was that
blockstore could be installed in *editable* mode,
but not as a built package:

    # Editable installation.
    # This worked, by chance.
    pip install -e git+https://github.com/openedx/blockstore.git@1.2.4#egg=blockstore==1.2.4
    python -c "from blockstore import apps"

    # Built installation.
    # This failed with "ImportError: cannot import name 'apps' from 'blockstore'"
    pip install "blockstore @ git+https://github.com/openedx/blockstore.git@1.2.4"
    python -c "from blockstore import apps"

If not fixed, this would become a problem when blockstore
is pushed to PyPI and installed as just:

    pip install openedx-blockstore

## Author Comments, Concerns, and Open Questions

This affects https://github.com/openedx/edx-platform/pull/30719, in which I'm trying to clean up edx-platform's github.in file to properly install a git-based dependencies.

## Test Instructions

In an LMS shell (`tutor local run lms bash` or `make lms-shell`):

    pip uninstall blockstore --yes
    pip install "blockstore @ git+https://github.com/kdmccormick/blockstore.git@kdmccormick/find-packages-not-manifest"
    python -c "from blockstore import apps"  # should print nothing


