### PR TITLE
Fix package name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ README = open(os.path.join(os.path.dirname(__file__), 'README.rst')).read()
 CHANGELOG = open(os.path.join(os.path.dirname(__file__), 'CHANGELOG.rst')).read()
 
 setup(
-    name='blockstore',
+    name='openedX-blockstore',
     version=VERSION,
     description="""Blockstore is a storage system for learning content in Open edX.""",
     long_description=README + '\n\n' + CHANGELOG,


### PR DESCRIPTION
## Description
The name `blockstore` is already taken on PyPI and hence release failed. Updating the package name in this PR to resolve the issue