### PR TITLE
fix: allow bundles to be created via django admin

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,17 +16,21 @@ Unreleased
 
 *
 
-[1.1.0] - 2021-10-25
+[1.3.0] - 2023-02-06
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Added
 _____
 
-* Move apps/api to apps/rest_api.
-* Copy edx-platform/openedx/core/lib/blockstore_api to blockstore/apps/api.
-  This code has been copied over so it is easier to review the Python API
-  implementation in development.
-* Make code into an installable package.
+* Adds support for installing this package as a wheel (``pip install openedx-blockstore``) rather than having to use editable mode (``pip install -e ./blockstore``).
+
+Changed
+_______
+
+* Fixes a bug where a new bundle's collection could not be set via Django admin.
+* Various configuration and build tooling fixes. See commit log of 1.2.0...1.3.0 for full details.
+
+
 
 [1.2.0] - 2021-01-25
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -40,3 +44,16 @@ Changed
 _______
 
 * Updates the Python API to use the models directly.
+
+[1.1.0] - 2021-10-25
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Added
+_____
+
+* Move apps/api to apps/rest_api.
+* Copy edx-platform/openedx/core/lib/blockstore_api to blockstore/apps/api.
+  This code has been copied over so it is easier to review the Python API
+  implementation in development.
+* Make code into an installable package.
+

--- a/blockstore/__init__.py
+++ b/blockstore/__init__.py
@@ -2,4 +2,4 @@
 Blockstore is a system for storing educational content.
 """
 
-__version__ = '1.2.6'
+__version__ = '1.3.0'

--- a/blockstore/apps/bundles/admin.py
+++ b/blockstore/apps/bundles/admin.py
@@ -74,10 +74,20 @@ class DraftInline(admin.StackedInline):
 
 
 class BundleAdmin(admin.ModelAdmin):
+    """
+    View for creating or updating Bundles and their BundleVersions & Drafts.
+    """
     list_display = ('uuid', 'slug', 'title')
-    readonly_fields = ('uuid',)
     inlines = (BundleVersionInline, DraftInline)
     search_fields = ('uuid', 'title')
+
+    def get_readonly_fields(self, request, obj=None):
+        if obj:
+            # Editing an existing Bundle: Do not allow collection to be edited.
+            return ('uuid', 'collection')
+        else:
+            # Creating a new Bundle: Allow the collection to be set.
+            return ('uuid',)
 
 
 class CollectionAdmin(admin.ModelAdmin):

--- a/blockstore/apps/bundles/models.py
+++ b/blockstore/apps/bundles/models.py
@@ -101,7 +101,7 @@ class Bundle(models.Model):
     title = models.CharField(max_length=MAX_CHAR_FIELD_LENGTH, db_index=True, db_collation=DB_COLLATION)
 
     collection = models.ForeignKey(
-        Collection, related_name="bundles", related_query_name="bundle", editable=False,
+        Collection, related_name="bundles", related_query_name="bundle",
         on_delete=models.CASCADE,
     )
 


### PR DESCRIPTION
## Description

fix: allow bundles to be created via django admin

Previously, trying to create a bundle would lead to the
message:

    IntegrityError at /admin/bundles/bundle/add/
    (1048, "Column 'collection_id' cannot be null")

because `collection` was indeed a required field, but
it was marked as editable=False, so it one could not
actually set it when making a new bundle.

With this change, we set editable=True, and add
some logic to the admin site so that the
`collection` field can be set when a bundle
is first created, but not afterwards.

This will trigger a migration, but since `editable`
is purely a Django-level validation field, no
changes should be seen in the MySQL schema.

## Author Comments, Concerns, and Open Questions

N/A

## Test Instructions

### Setup

Get blockstore running in a dev env, and make sure at least one Collection is created. I chose to use Tutor plus the [library authoring Tutor plugin](https://github.com/openedx/frontend-app-library-authoring/tree/master/tutor-contrib-library-authoring-mfe), which uses Blockstore as a CMS app.

### Reproducing the bug

In CMS admin, go to add a bundle (http://studio.local.overhang.io:8001/admin/bundles/bundle/add/)

Clicking "Save" from here:

![image](https://user-images.githubusercontent.com/3628148/217049390-1a20f1b8-6e5c-46fb-85d1-295786d434bf.png)

Gives:
```
IntegrityError at /admin/bundles/bundle/add/

(1048, "Column 'collection_id' cannot be null")
```
### Testing the fix

In CMS admin, go to add a bundle (http://studio.local.overhang.io:8001/admin/bundles/bundle/add/)

Notice that you are now able to select a Collection. Clicking Save should work:

![image](https://user-images.githubusercontent.com/3628148/217076791-5c58379b-2c8e-44ec-8fba-2cd5a3dac224.png)
![image](https://user-images.githubusercontent.com/3628148/217076839-2ecfd864-b038-42ff-863c-cf838b258a6b.png)

Clicking into the Bundle you created should display a link to the Collection, but not allow you to edit it:

![image](https://user-images.githubusercontent.com/3628148/217076946-e77eba6b-4688-4721-b150-94f7d9f0e582.png)

## TODOs

Tag 1.3.0 once this merges.
