### PR TITLE
docs: Update the contributing guidelines link.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -176,7 +176,7 @@ Ask questions and discuss this project on `Slack <https://openedx.slack.com/mess
 Contributing
 ------------
 
-Contributions are welcome. Please read `How To Contribute <https://github.com/openedx/edx-platform/blob/master/CONTRIBUTING.rst>`_ for details. Even though it was written with ``edx-platform`` in mind, these guidelines should be followed for Open edX code in general.
+Contributions are welcome. Please read `How To Contribute <https://github.com/openedx/.github/blob/master/CONTRIBUTING.md>`_ for details.
 
 ----------------------------
 The Open edX Code of Conduct


### PR DESCRIPTION
We're moving towards a single set of guidelines org-wide.
