### PR TITLE
chore: Pin `urllib3<2.0.0` version

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,7 +8,7 @@ asgiref==3.6.0
     # via django
 attrs==23.1.0
     # via -r requirements/base.in
-certifi==2022.12.7
+certifi==2023.5.7
     # via requests
 cffi==1.15.1
     # via
@@ -32,7 +32,7 @@ defusedxml==0.7.1
     # via
     #   python3-openid
     #   social-auth-core
-django==3.2.18
+django==3.2.19
     # via
     #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt
@@ -101,7 +101,7 @@ psutil==5.9.5
     # via edx-django-utils
 pycparser==2.21
     # via cffi
-pyjwt[crypto]==2.6.0
+pyjwt[crypto]==2.7.0
     # via
     #   edx-auth-backends
     #   social-auth-core
@@ -117,14 +117,14 @@ pytz==2023.3
     #   drf-yasg
 pyyaml==6.0
     # via edx-django-release-util
-requests==2.29.0
+requests==2.30.0
     # via
     #   coreapi
     #   requests-oauthlib
     #   social-auth-core
 requests-oauthlib==1.3.1
     # via social-auth-core
-ruamel-yaml==0.17.21
+ruamel-yaml==0.17.26
     # via drf-yasg
 ruamel-yaml-clib==0.2.7
     # via ruamel-yaml
@@ -149,4 +149,6 @@ uritemplate==4.1.1
     #   coreapi
     #   drf-yasg
 urllib3==1.26.15
-    # via requests
+    # via
+    #   -c requirements/constraints.txt
+    #   requests

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -16,3 +16,7 @@
 boto3<2.0
 
 django>3.2,<3.3
+
+# `botocore` still requires `urllib3>=1.25.4,<1.27`: https://github.com/boto/botocore/issues/2926
+# `edx-platform` also pins `urllib3<2.0.0`: https://github.com/openedx/edx-platform/issues/32222
+urllib3<2.0.0

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -8,7 +8,7 @@ alabaster==0.7.13
     # via sphinx
 babel==2.12.1
     # via sphinx
-certifi==2022.12.7
+certifi==2023.5.7
     # via requests
 charset-normalizer==3.1.0
     # via requests
@@ -32,7 +32,7 @@ pygments==2.15.1
     # via sphinx
 pytz==2023.3
     # via babel
-requests==2.29.0
+requests==2.30.0
     # via sphinx
 six==1.16.0
     # via edx-sphinx-theme
@@ -56,6 +56,8 @@ sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
 urllib3==1.26.15
-    # via requests
+    # via
+    #   -c requirements/constraints.txt
+    #   requests
 zipp==3.15.0
     # via importlib-metadata

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -12,7 +12,7 @@ asgiref==3.6.0
     # via
     #   -r requirements/test.txt
     #   django
-astroid==2.15.4
+astroid==2.15.5
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -23,7 +23,7 @@ babel==2.12.1
     # via
     #   -r requirements/docs.txt
     #   sphinx
-certifi==2022.12.7
+certifi==2023.5.7
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
@@ -88,7 +88,7 @@ dill==0.3.6
     # via
     #   -r requirements/test.txt
     #   pylint
-django==3.2.18
+django==3.2.19
     # via
     #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt
@@ -154,7 +154,7 @@ exceptiongroup==1.1.1
     #   pytest
 factory-boy==3.2.1
     # via -r requirements/test.txt
-faker==18.6.0
+faker==18.7.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -208,7 +208,7 @@ mccabe==0.7.0
     # via
     #   -r requirements/test.txt
     #   pylint
-mypy==1.2.0
+mypy==1.3.0
     # via -r requirements/test.txt
 mypy-extensions==1.0.0
     # via
@@ -236,7 +236,7 @@ pbr==5.11.1
     # via
     #   -r requirements/test.txt
     #   stevedore
-platformdirs==3.5.0
+platformdirs==3.5.1
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -261,12 +261,12 @@ pygments==2.15.1
     #   -r requirements/test.txt
     #   diff-cover
     #   sphinx
-pyjwt[crypto]==2.6.0
+pyjwt[crypto]==2.7.0
     # via
     #   -r requirements/test.txt
     #   edx-auth-backends
     #   social-auth-core
-pylint==2.17.3
+pylint==2.17.4
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -281,7 +281,7 @@ pylint-django==2.5.3
     # via
     #   -r requirements/test.txt
     #   edx-lint
-pylint-plugin-utils==0.7
+pylint-plugin-utils==0.8.1
     # via
     #   -r requirements/test.txt
     #   pylint-celery
@@ -324,7 +324,7 @@ pyyaml==6.0
     #   -r requirements/test.txt
     #   code-annotations
     #   edx-django-release-util
-requests==2.29.0
+requests==2.30.0
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
@@ -336,7 +336,7 @@ requests-oauthlib==1.3.1
     # via
     #   -r requirements/test.txt
     #   social-auth-core
-ruamel-yaml==0.17.21
+ruamel-yaml==0.17.26
     # via
     #   -r requirements/test.txt
     #   drf-yasg
@@ -434,6 +434,7 @@ uritemplate==4.1.1
     #   drf-yasg
 urllib3==1.26.15
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   requests

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -10,15 +10,15 @@ asgiref==3.6.0
     #   django
 attrs==23.1.0
     # via -r requirements/base.txt
-boto3==1.26.123
+boto3==1.26.133
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/production.in
-botocore==1.29.123
+botocore==1.29.133
     # via
     #   boto3
     #   s3transfer
-certifi==2022.12.7
+certifi==2023.5.7
     # via
     #   -r requirements/base.txt
     #   requests
@@ -54,7 +54,7 @@ defusedxml==0.7.1
     #   -r requirements/base.txt
     #   python3-openid
     #   social-auth-core
-django==3.2.18
+django==3.2.19
     # via
     #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt
@@ -162,7 +162,7 @@ pycparser==2.21
     # via
     #   -r requirements/base.txt
     #   cffi
-pyjwt[crypto]==2.6.0
+pyjwt[crypto]==2.7.0
     # via
     #   -r requirements/base.txt
     #   edx-auth-backends
@@ -190,7 +190,7 @@ pyyaml==6.0
     #   -r requirements/base.txt
     #   -r requirements/production.in
     #   edx-django-release-util
-requests==2.29.0
+requests==2.30.0
     # via
     #   -r requirements/base.txt
     #   coreapi
@@ -200,7 +200,7 @@ requests-oauthlib==1.3.1
     # via
     #   -r requirements/base.txt
     #   social-auth-core
-ruamel-yaml==0.17.21
+ruamel-yaml==0.17.26
     # via
     #   -r requirements/base.txt
     #   drf-yasg
@@ -208,7 +208,7 @@ ruamel-yaml-clib==0.2.7
     # via
     #   -r requirements/base.txt
     #   ruamel-yaml
-s3transfer==0.6.0
+s3transfer==0.6.1
     # via boto3
 six==1.16.0
     # via
@@ -241,6 +241,7 @@ uritemplate==4.1.1
     #   drf-yasg
 urllib3==1.26.15
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   botocore
     #   requests

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -8,14 +8,14 @@ asgiref==3.6.0
     # via
     #   -r requirements/base.txt
     #   django
-astroid==2.15.4
+astroid==2.15.5
     # via
     #   -r requirements/test.in
     #   pylint
     #   pylint-celery
 attrs==23.1.0
     # via -r requirements/base.txt
-certifi==2022.12.7
+certifi==2023.5.7
     # via
     #   -r requirements/base.txt
     #   requests
@@ -70,7 +70,7 @@ diff-cover==7.5.0
     # via -r requirements/test.in
 dill==0.3.6
     # via pylint
-django==3.2.18
+django==3.2.19
     # via
     #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt
@@ -125,7 +125,7 @@ exceptiongroup==1.1.1
     # via pytest
 factory-boy==3.2.1
     # via -r requirements/test.in
-faker==18.6.0
+faker==18.7.0
     # via factory-boy
 idna==3.4
     # via
@@ -157,7 +157,7 @@ markupsafe==2.1.2
     #   jinja2
 mccabe==0.7.0
     # via pylint
-mypy==1.2.0
+mypy==1.3.0
     # via -r requirements/test.in
 mypy-extensions==1.0.0
     # via mypy
@@ -181,7 +181,7 @@ pbr==5.11.1
     # via
     #   -r requirements/base.txt
     #   stevedore
-platformdirs==3.5.0
+platformdirs==3.5.1
     # via pylint
 pluggy==1.0.0
     # via
@@ -199,12 +199,12 @@ pycparser==2.21
     #   cffi
 pygments==2.15.1
     # via diff-cover
-pyjwt[crypto]==2.6.0
+pyjwt[crypto]==2.7.0
     # via
     #   -r requirements/base.txt
     #   edx-auth-backends
     #   social-auth-core
-pylint==2.17.3
+pylint==2.17.4
     # via
     #   edx-lint
     #   pylint-celery
@@ -214,7 +214,7 @@ pylint-celery==0.3
     # via edx-lint
 pylint-django==2.5.3
     # via edx-lint
-pylint-plugin-utils==0.7
+pylint-plugin-utils==0.8.1
     # via
     #   pylint-celery
     #   pylint-django
@@ -250,7 +250,7 @@ pyyaml==6.0
     #   -r requirements/base.txt
     #   code-annotations
     #   edx-django-release-util
-requests==2.29.0
+requests==2.30.0
     # via
     #   -r requirements/base.txt
     #   coreapi
@@ -260,7 +260,7 @@ requests-oauthlib==1.3.1
     # via
     #   -r requirements/base.txt
     #   social-auth-core
-ruamel-yaml==0.17.21
+ruamel-yaml==0.17.26
     # via
     #   -r requirements/base.txt
     #   drf-yasg
@@ -316,6 +316,7 @@ uritemplate==4.1.1
     #   drf-yasg
 urllib3==1.26.15
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   requests
 wrapt==1.15.0


### PR DESCRIPTION
## Description

This pins `urllib3<2.0.0` because of the existing dependency constraints:
1. https://github.com/boto/botocore/issues/2926
2. https://github.com/openedx/edx-platform/issues/32222

Related upgrade workflow failure: https://github.com/openedx/blockstore/actions/runs/4975196112/jobs/8902138260.

## Test Instructions

Check that the CI is passing.

## TODOs
If anything isn't yet done, list it here
- [x] Squash before merging