### PR TITLE
feat: add no-request uri fallback

### DIFF
--- a/blockstore/apps/api/methods.py
+++ b/blockstore/apps/api/methods.py
@@ -2,12 +2,11 @@
 API Client methods for working with Blockstore bundles and drafts
 """
 
-from django.conf import settings
-
 import base64
 import re
 from crum import get_current_request
 
+from django.conf import settings
 from django.db.models import Q
 from rest_framework import serializers
 

--- a/blockstore/apps/api/methods.py
+++ b/blockstore/apps/api/methods.py
@@ -2,6 +2,8 @@
 API Client methods for working with Blockstore bundles and drafts
 """
 
+from django.conf import settings
+
 import base64
 import re
 from crum import get_current_request
@@ -485,6 +487,11 @@ def _build_absolute_uri(url):
     Build an absolute URI from the given url, using the CRUM middleware's stored request.
     """
     request = get_current_request()
+    if not request: # this method can be called from internal python apis. In that case, return a simple uri.
+        if url.startswith('https://'):
+            return url
+        return settings.LMS_ROOT_URL + url
+
     return request.build_absolute_uri(url)
 
 

--- a/blockstore/apps/api/methods.py
+++ b/blockstore/apps/api/methods.py
@@ -487,7 +487,7 @@ def _build_absolute_uri(url):
     Build an absolute URI from the given url, using the CRUM middleware's stored request.
     """
     request = get_current_request()
-    if not request: # this method can be called from internal python apis. In that case, return a simple uri.
+    if not request:  # this method can be called from internal python apis. In that case, return a simple uri.
         if url.startswith('https://'):
             return url
         return settings.LMS_ROOT_URL + url


### PR DESCRIPTION
## Description

I ran into the following issue:

> I’m building out a management command to import V1 content Libraries into V2 content libraries. I’m using import_blocks_create_task which works 99% of the way for V1 libraries.
> I’ve run into an interesting conundrum. I can get all the data from V1 libs without issue. I can even make a library block which contains that data.
> The import, however fails, because upon creation, it returns the metadata object about the block it just created using get_library_block (which makes sense).
> that call makes a call to blockstore, obviously, which makes a bunch of calls, one of which is to [_build_absolute_uri](https://github.com/openedx/blockstore/blob/d65ecd865ce88b0abd01f54885be446209abd6b0/blockstore/apps/api/methods.py#L483)  which pulls the request from CRUM middleware and builds the URI from that.
> The issue is, there is no request in the CRUM middleware because this is a management command, not a user request…
> consequently, I get AttributeError: 'NoneType' object has no attribute 'build_absolute_uri'

THe way I fixed this, is by changing _build_absolute_uri so that it can fall back to settings.LMS_ROOT_URL to build the absolute URI if there is no current request. 
