### PR TITLE
chore: update Django to 3.2.23 for Quince - Security Patch

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -26,7 +26,7 @@ defusedxml==0.8.0rc2
     # via
     #   python3-openid
     #   social-auth-core
-django==3.2.22
+django==3.2.23
     # via
     #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -88,7 +88,7 @@ dill==0.3.7
     # via
     #   -r requirements/test.txt
     #   pylint
-django==3.2.22
+django==3.2.23
     # via
     #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -45,7 +45,7 @@ defusedxml==0.8.0rc2
     #   -r requirements/base.txt
     #   python3-openid
     #   social-auth-core
-django==3.2.22
+django==3.2.23
     # via
     #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -61,7 +61,7 @@ diff-cover==7.7.0
     # via -r requirements/test.in
 dill==0.3.7
     # via pylint
-django==3.2.22
+django==3.2.23
     # via
     #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt


### PR DESCRIPTION
### Description
This PR updates Django to version 3.2.23 in the Quince release branch. The update includes the latest security patch, as part of the BTR working group's ongoing efforts to ensure the security of Open edX's supported named releases.

For more information, see: [https://github.com/openedx/wg-build-test-release/issues/324](https://github.com/openedx/wg-build-test-release/issues/324)